### PR TITLE
feat: Add user-specific deep link converter

### DIFF
--- a/api/deeplink_routes.py
+++ b/api/deeplink_routes.py
@@ -3,8 +3,18 @@ Deep Link Routes
 
 Routes for handling YouTube deep link conversion
 """
-from flask import Blueprint, render_template, request, url_for, abort
+from flask import Blueprint, render_template, request, url_for, abort, session, redirect
 from services.deeplink_service import extract_video_id, validate_video_id
+from functools import wraps
+
+# Placeholder login_required decorator
+def login_required(f):
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        if 'user_id' not in session: # Assumes 'user_id' is set in session upon login
+            return redirect(url_for('auth.login', next=request.url)) # 'auth.login' is typical for a login route
+        return f(*args, **kwargs)
+    return decorated_function
 
 deeplink_bp = Blueprint('deeplink', __name__)
 
@@ -37,3 +47,33 @@ def dl_redirect(video_id):
         abort(404)
         
     return render_template('redirect.html', video_id=video_id)
+
+
+@deeplink_bp.route('/profile/deeplink', methods=['GET', 'POST'])
+@login_required
+def user_deeplink_converter_page():
+    user_email = session.get('user_email')
+    deep_url = None
+    error = None
+    original_url = None
+    success_message = None
+
+    if request.method == 'POST':
+        youtube_url = request.form.get('youtube_url', '')
+        original_url = youtube_url
+        video_id = extract_video_id(youtube_url)
+
+        if not video_id or not validate_video_id(video_id):
+            error = "Invalid YouTube URL. Please enter a valid URL."
+        else:
+            deep_url = url_for('deeplink.dl_redirect', video_id=video_id, _external=True)
+            success_message = "Successfully converted your link!"
+
+        return render_template('user_deeplink_converter.html',
+                               deep_url=deep_url,
+                               error=error,
+                               original_url=original_url,
+                               user_email=user_email,
+                               success_message=success_message)
+
+    return render_template('user_deeplink_converter.html', user_email=user_email)

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -40,6 +40,7 @@
             <h2 class="mb-1">Welcome{% if user_name %}, {{ user_name }}{% elif user_email %}, {{ user_email }}{% endif %}</h2>
             <p class="text-muted mb-3">User ID: <span class="fw-bold">{{ user_id }}</span></p>
             <a href="{{ url_for('auth.logout') }}" class="btn btn-outline-secondary btn-sm">Logout</a>
+            <a href="{{ url_for('deeplink.user_deeplink_converter_page') }}" class="btn btn-primary mt-3">Create Deep Link</a>
         </div>
     </div>
 </body>

--- a/templates/user_deeplink_converter.html
+++ b/templates/user_deeplink_converter.html
@@ -1,0 +1,103 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Your Personal Deep Link Converter</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}"> <!-- Optional: if common styles are needed -->
+  <style>
+    /* Custom styles can be kept minimal if Bootstrap and style.css are sufficient */
+    .results {
+      margin-top: 2rem; /* Bootstrap 'mt-4' or 'mt-5' could also be used */
+      padding: 1.5rem; /* Bootstrap 'p-3' or 'p-4' */
+      border: 1px solid #dee2e6; /* Bootstrap 'border' */
+      border-radius: 0.375rem; /* Bootstrap 'rounded' */
+    }
+  </style>
+</head>
+<body>
+  <div class="container py-4">
+    <header class="mb-4">
+      <h1>Your Personal Deep Link Converter</h1>
+      {% if user_email %}
+      <p class="lead">Welcome, {{ user_email }}!</p>
+      {% endif %}
+    </header>
+
+    {% if error %}
+      <div class="alert alert-danger">{{ error }}</div>
+    {% endif %}
+
+    <form method="POST" action="{{ url_for('deeplink.user_deeplink_converter_page') }}" class="mb-4">
+      <div class="mb-3">
+        <label for="youtube_url" class="form-label">YouTube URL</label>
+        <input type="url" class="form-control" id="youtube_url" name="youtube_url" value="{{ original_url or '' }}" required>
+      </div>
+      <button type="submit" class="btn btn-primary">
+        <i class="fas fa-sync-alt me-2"></i>Convert
+      </button>
+    </form>
+
+    {% if deep_url %}
+      <div class="results">
+        {% if success_message %}
+          <div class="alert alert-success">{{ success_message }}</div>
+        {% endif %}
+        <div class="mb-3">
+            <label class="form-label">Original URL:</label>
+            <input type="text" class="form-control" value="{{ original_url }}" readonly>
+            <!-- Or just display as text: <p><a href="{{ original_url }}" target="_blank">{{ original_url }}</a></p> -->
+        </div>
+        <div class="mb-3">
+          <label for="deep_link_output" class="form-label">Your Deep Link:</label>
+          <div class="input-group">
+            <input type="text" id="deep_link_output" class="form-control" value="{{ deep_url }}" readonly>
+            <button class="btn btn-outline-secondary" type="button" onclick="copyToClipboard(this)">
+              <i class="far fa-copy me-2"></i>Copy
+            </button>
+          </div>
+        </div>
+      </div>
+    {% endif %}
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+  <script>
+    function copyToClipboard(button) {
+      const inputElement = document.getElementById("deep_link_output"); // More direct selection
+      if (!inputElement) return;
+
+      inputElement.select();
+      inputElement.setSelectionRange(0, 99999); // For mobile devices
+
+      navigator.clipboard.writeText(inputElement.value).then(() => {
+        const originalText = button.innerHTML;
+        const originalIcon = button.querySelector('i') ? button.querySelector('i').outerHTML : '<i class="far fa-copy me-2"></i>'; // Save original icon
+
+        button.innerHTML = '<i class="fas fa-check me-2"></i>Copied!';
+        button.classList.remove('btn-outline-secondary');
+        button.classList.add('btn-success'); // Change to success style
+        button.disabled = true;
+
+        setTimeout(() => {
+          button.innerHTML = originalIcon + 'Copy'; // Restore original text/icon
+          button.classList.remove('btn-success');
+          button.classList.add('btn-outline-secondary');
+          button.disabled = false;
+        }, 2000);
+      }).catch(err => {
+        console.error('Failed to copy text: ', err);
+        // Fallback for older browsers (less common now)
+        try {
+          document.execCommand("copy");
+          alert("Copied the deep link: " + inputElement.value); // Simple feedback for fallback
+        } catch (e) {
+          alert("Failed to copy. Please select and copy manually.");
+        }
+      });
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
This commit introduces a new deep link conversion feature accessible to logged-in users from their profile page.

Key changes:
- Added a new page at `/profile/deeplink` where authenticated users can convert YouTube URLs into deep links.
- The converter displays your email, the original YouTube URL, the generated deep link, and a success message.
- A `login_required` decorator ensures only authenticated users can access this page.
- Your profile page (`/profile`) now includes a button linking to this new converter.
- The UI of the new converter page has been styled using Bootstrap 5 and includes a "Copy to Clipboard" functionality for the generated deep link.
- Existing deep link generation logic in `services/deeplink_service.py` for YouTube URLs is reused.

This feature allows you to easily generate deep links for your YouTube content and provides a foundation for potential future enhancements to the deep linking service as outlined in the PRD.